### PR TITLE
correct comment syntax & cheat sheet links

### DIFF
--- a/core/style.md
+++ b/core/style.md
@@ -57,7 +57,7 @@ value of this property.
 The right sytrax is:
 
     selector {
-        property: value; ** remember always to write a ; after your value **
+        property: value; /* remember always to write a ; after your value */
         property: value;
     }
 

--- a/index.md
+++ b/index.md
@@ -73,9 +73,9 @@ about what's next.
 
 ## Cheat Sheet
 
-* <a href="http://media.smashingmagazine.com/wp-content/uploads/images/html5-cheat-sheet/html5-cheat-sheet.pdf" target= "_blank" > 
+* <a href="http://www.smashingmagazine.com/2009/07/06/html-5-cheat-sheet-pdf/" target= "_blank" > 
   HTML5 </a> - Use this sheet for try out new HTML tag.
-* <a href="http://media.smashingmagazine.com/wp-content/uploads/images/css3-cheat-sheet/css3-cheat-sheet.pdf" target= "_blank" >
+* <a href="http://coding.smashingmagazine.com/2009/07/13/css-3-cheat-sheet-pdf/" target= "_blank" >
   CSS3</a> - Use this sheet for try out new CSS selectors.
 
 


### PR DESCRIPTION
Use the correct css comment syntax (/\* comment _/ instead of *_ comment **)
