### PR TITLE
Bugfix for CSS code for Navigation section, nav li color number had extr...

### DIFF
--- a/core/portfolio.md
+++ b/core/portfolio.md
@@ -107,7 +107,7 @@ In styles.css:
 
     nav li {
         display: inline;
-        color: ##08c;
+        color: #08c;
     }
 
 Nav ul is a way to specify not all the ul elements on the page but just the one that is nav's child.


### PR DESCRIPTION
Fix for Issue https://github.com/OpenTechSchool/html-css-beginners/issues/22

Removed extra # on the CSS code for the Navigation section of the Portfolio exercise
